### PR TITLE
Fix stupid typo in volume allocations

### DIFF
--- a/prometheus-dc.yaml
+++ b/prometheus-dc.yaml
@@ -91,7 +91,7 @@ spec:
             name: prometheus
           name: config-volume
         - name: data-volume
-          PersistentVolumeClaim:
+          persistentVolumeClaim:
             claimName: prometheus-claim
   triggers:
     - type: ConfigChange


### PR DESCRIPTION
Found why you put "oc volume -add" initially. Probably "oc" should have "lint mode for config files" to catch this.